### PR TITLE
Send the query context to the callback

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,10 +9,12 @@ module.exports = function(schema, pluginOptions) {
     }
 
     var options = { explain: true };
+    var self = this;
+
     options.fields = this._castFields(this._fields);
     this._collection.findOne(this._conditions, options, function(error, stats) {
       if (get(pluginOptions, 'callback') != null) {
-        pluginOptions.callback(stats);
+        pluginOptions.callback(stats, self);
       } else {
         console.dir(stats, { depth: null, colors: true });
       }
@@ -26,10 +28,12 @@ module.exports = function(schema, pluginOptions) {
     }
 
     var options = { explain: true };
+    var self = this;
+
     options.fields = this._castFields(this._fields);
     this._collection.find(this._conditions, options, function(error, stats) {
       if (get(pluginOptions, 'callback') != null) {
-        pluginOptions.callback(stats);
+        pluginOptions.callback(stats, self);
       } else {
         console.dir(stats, { depth: null, colors: true });
       }
@@ -49,9 +53,11 @@ function instrumentAggregate(schema, pluginOptions) {
     }
 
     var options = { explain: true };
+    var self = this;
+
     this._model.collection.aggregate(this._pipeline, options, function(error, stats) {
       if (pluginOptions && pluginOptions.callback) {
-        pluginOptions.callback(stats);
+        pluginOptions.callback(stats, self);
       } else {
         console.dir(stats, { depth: null, colors: true });
       }

--- a/test/test.js
+++ b/test/test.js
@@ -55,7 +55,7 @@ describe('mongoose-explain', function() {
     var explainResults = [];
 
     schema.plugin(explain, {
-      callback: function(res) { explainResults.push(res); }
+      callback: function(res, query) { explainResults.push([res, query]); }
     });
 
     var Author = mongoose.model('Author2', schema, 'author');
@@ -64,6 +64,8 @@ describe('mongoose-explain', function() {
       assert.ifError(error);
       assert.equal(doc.author, 'Val');
       assert.equal(explainResults.length, 1);
+      assert.equal(explainResults[0][1].model, Author);
+      assert.equal(explainResults[0][1].op, 'findOne');
       done();
     });
   });
@@ -72,7 +74,7 @@ describe('mongoose-explain', function() {
     var explainResults = [];
 
     schema.plugin(explain, {
-      callback: function(res) { explainResults.push(res); }
+      callback: function(res, query) { explainResults.push([res, query]); }
     });
 
     var Author = mongoose.model('Author3', schema, 'author');
@@ -81,6 +83,7 @@ describe('mongoose-explain', function() {
       assert.ifError(error);
       assert.equal(res.length, 1);
       assert.equal(explainResults.length, 1);
+      assert.equal(explainResults[0][1]._model, Author);
       done();
     });
   });


### PR DESCRIPTION
This PR allows the callback to receive the query context so one could extract more information for debugging.

```
mongoose.plugin(explain, {
  callback: (res, query) => console.log('Model: %s', query.model.modelName)
});
```